### PR TITLE
完成绑定模式

### DIFF
--- a/config-server/templates/mykeymap.tmpl
+++ b/config-server/templates/mykeymap.tmpl
@@ -48,19 +48,10 @@ InitKeymap()
   ; 窗口组
 {{ .WindowGroups -}}
 
-{{range .EnabledKeymaps}}{{template "renderKeymap" .}}{{end}}
+{{range .EnabledKeymaps}}{{renderKeymap .}}{{end}}
 
   KeymapManager.GlobalKeymap.Enable()
 }
-
-{{define "renderKeymap"}}
-  ; {{.Name}}
-  {{ if not .ParentID }}km{{ .ID }} := KeymapManager.NewKeymap("{{ .Hotkey }}", {{ ahkString .Name }}, "{{ divide .Delay 1000 }}"){{ else }}km{{ .ID }} := KeymapManager.AddSubKeymap(km{{ .ParentID }}, "{{ .Hotkey }}", {{ ahkString .Name }}){{ end }}
-  km := km{{ .ID -}}
-{{ range $index, $action := sortHotkeys .Hotkeys }}
-  {{ actionToHotkey $action }}
-{{- end }}
-{{ end }}
 
 {{- if .CapslockAbbrEnabled -}}
 ExecCapslockAbbr(command) {

--- a/data/custom_functions.ahk
+++ b/data/custom_functions.ahk
@@ -1,4 +1,9 @@
 ﻿; 自定义的函数写在这个文件里,  然后能在 MyKeymap 中调用
+; 是否启用按键记录，用来 Debug
+; KeyHistory
+
+; 使用如下写法，来加载当前目录下的其他AutoHotKey2脚本
+; #Include ../data/test.ahk
 
 sendSomeChinese() {
   Send("{text}你好中文!")


### PR DESCRIPTION
使用方法只需要在名称前加上$符号，快捷键绑定内容会自动生成，优先级低于自定义热键

不影响未绑定的快捷键

例子：
```ahk
  ; $Win
  km5 := KeymapManager.NewKeymap("customHotkeys", "$Win", "")
  km := km5 
  km.Map("#*t", _ => ActivateOrRun("", "shortcuts\Notepad3.lnk"))
  km.Map("#+*", _ => SoundControl())
  km.Map("#*m", _ => ToggleWindowTopMost())
  km.Map("#*q", _ => SmartCloseWindow())
  km.Map("#*s", _ => MaximizeWindow())
  km.RemapKey("#*z", "RWin")
  km.Map("#*1", _ => GoToDesktopNumber(0))
  km.Map("#*2", _ => GoToDesktopNumber(1))
  km.Map("#*3", _ => GoToDesktopNumber(2))
  km.Map("#*4", _ => GoToDesktopNumber(3))
  km.Map("#*tab", _ => TabDesktop())


  ; $Win + Shift
  km18 := KeymapManager.NewKeymap("customHotkeys", "$Win + Shift", "")
  km := km18 
  km.RemapKey("+#*z", "RWin")
  km.Map("+#*1", _ => MoveCurrentWindowToDesktops(0))
  km.Map("+#*2", _ => MoveCurrentWindowToDesktops(1))
  km.Map("+#*3", _ => MoveCurrentWindowToDesktops(2))
  km.Map("+#*4", _ => MoveCurrentWindowToDesktops(3))
  km.Map("+#*left", _ => GoToPrevDesktop())
  km.Map("+#*right", _ => GoToNextDesktop())


  ; 自定义热键
  km1 := KeymapManager.NewKeymap("customHotkeys", "自定义热键", "")
  km := km1 
  km.Map("RWin", _ => SoundControl())
```