### PR TITLE
修复若 MyKeymap.exe 同级目录若存在 shortcuts 文件导致 shortcuts 文件夹无法生成的问题

### DIFF
--- a/bin/MiscTools.ahk
+++ b/bin/MiscTools.ahk
@@ -9,7 +9,11 @@ if !A_Args.Length {
 }
 
 if A_Args[1] = "GenerateShortcuts" {
+  ; 由于 windows 系统不允许存在同名文件和文件夹，故预先删除之
+  try FileDelete("shortcuts")
   try DirDelete("shortcuts", true)
+  ; 休息 0.05 s，防止 delete 操作未完成引起的 shortcuts 目录被占用问题
+  Sleep(50)
   try DirCreate("shortcuts")
 
   ; 把开始菜单中的快捷方式都拷贝到 shortcuts 目录


### PR DESCRIPTION
休息 0.05 s，防止 delete 操作未完成引起的 shortcuts 目录被占用问题：加了 sleep 几乎就好了，可能是我机器太卡了

![未生成](https://github.com/xianyukang/MyKeymap/assets/10010627/1e531752-192c-4c90-ab3c-b3b4948d6560)