### PR TITLE
修复 A_StartupCommon 和 A_Startup 排除 lnk 文件不生效的问题

### DIFF
--- a/bin/MiscTools.ahk
+++ b/bin/MiscTools.ahk
@@ -12,9 +12,23 @@ if A_Args[1] = "GenerateShortcuts" {
   try DirDelete("shortcuts", true)
   try DirCreate("shortcuts")
 
+  ; 排除特定的快捷方式  
+  useless := "i)(?:uninstall|卸载|help|iSCSI 发起程序|ODBC 数据源|Data Sources \(ODBC\)"
+    . "|ODBC Data|Windows 内存诊断|恢复驱动器|组件服务|碎片整理和优化驱动器|Office 语言首选项"
+    . "|手册|更新|帮助|Tools Command Prompt for|license|Website|设置向导|More Games from Microsoft"
+    . "|细胞词库|意见反馈|输入法管理器|输入法修复器|皮肤下载|官方网站|Microsoft Office 语言设置"
+    . "|Microsoft Office 文档关联中心|Internet Explorer \(No Add-ons\)"
+    . "|Windows Easy Transfer Reports|Welcome Center|Microsoft Office 2007 控制中心"
+
+  Loop Files A_StartupCommon . "\*.lnk*"
+    useless .= "|" . A_LoopFileName
+  Loop Files A_Startup . "\*.lnk*"
+    useless .= "|" . A_LoopFileName
+  useless .= ")"
+
   ; 把开始菜单中的快捷方式都拷贝到 shortcuts 目录
-  copyFiles(A_ProgramsCommon "\*.lnk", "shortcuts\", A_StartupCommon)
-  copyFiles(A_Programs "\*.lnk", "shortcuts\", A_Startup)
+  copyFiles(A_ProgramsCommon "\*.lnk", "shortcuts\", useless)
+  copyFiles(A_Programs "\*.lnk", "shortcuts\", useless)
   ; 然后再生成 UWP 相关的快捷方式
   oFolder := ComObject("Shell.Application").NameSpace("shell:AppsFolder")
   for item in oFolder.Items {
@@ -23,16 +37,8 @@ if A_Args[1] = "GenerateShortcuts" {
     }
     try FileCreateShortcut("shell:appsfolder\" item.Path, "shortcuts\" item.Name ".lnk")
   }
-  ; 删除无用快捷方式
-  useless := "i)(uninstall|卸载|help|iSCSI 发起程序|ODBC 数据源|ODBC Data|Windows 内存诊断|恢复驱动器|组件服务|碎片整理和优化驱动器|Office 语言首选项|手册|更新|帮助|Tools Command Prompt for|license|Website)"
-  Loop Files "shortcuts\*.*" {
-    if RegExMatch(A_LoopFileName, useless) {
-      FileDelete(A_LoopFilePath)
-    }
-  }
   return
 }
-
 
 if A_Args[1] = "RunAtStartup" {
   linkFile := A_Startup "\MyKeymap.lnk"
@@ -48,7 +54,7 @@ if A_Args[1] = "RunAtStartup" {
 
 copyFiles(pattern, dest, ignore := "") {
   Loop Files pattern, "R" {
-    if ignore != "" && InStr(A_LoopFilePath, ignore) {
+    if (A_LoopFileName ~= ignore) {
       continue
     }
     try FileCopy(A_LoopFilePath, dest, true)


### PR DESCRIPTION
useless 新增了 搜狗输入法恶意添加的输入法管理器、输入法修复器等工具的快捷方式

先插再删改成了有过滤的删，避免多次操作文件